### PR TITLE
Convert pvs/nodejs_testing to GitHub Actions

### DIFF
--- a/.github/workflows/nodejs_testing.yml
+++ b/.github/workflows/nodejs_testing.yml
@@ -1,0 +1,31 @@
+name: pvs/nodejs_testing
+on:
+  workflow_dispatch:
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.5.0
+    - name: sh
+      shell: bash
+      run: npm install
+  Build_pm2:
+    name: Build pm2
+    runs-on: ubuntu-latest
+    needs: Build
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.5.0
+    - name: sh
+      shell: bash
+      run: npm install pm2 -g
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: Build_pm2
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.5.0
+    - name: sh
+      shell: bash
+      run: pm2 startOrRestart pm2.config.json


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://13.127.6.236:8080/job/pvs/job/nodejs_testing/) :tada:

## Manual steps

Perform the following steps to complete the migration:

### pvs/nodejs_testing
- [ ] Ensure build tool is available: `nodejs`